### PR TITLE
Watch later

### DIFF
--- a/src/components/HorizontalVideoCard/HorizontalVideoCard.jsx
+++ b/src/components/HorizontalVideoCard/HorizontalVideoCard.jsx
@@ -6,7 +6,7 @@ export const HorizontalVideoCard = ({
   videoTime,
   videoTitle,
   channelName,
-  removeFromLikes,
+  removeVideo,
 }) => {
   return (
     <div className="horizontal-video-card">
@@ -27,7 +27,7 @@ export const HorizontalVideoCard = ({
       <div className="hc-button-container">
         <button
           className="button btn-secondary delete-button"
-          onClick={() => removeFromLikes(videoId)}
+          onClick={() => removeVideo(videoId)}
         >
           <i className="fas fa-trash"></i>
         </button>

--- a/src/components/VideoDisplay/VideoCard/VideoCard.jsx
+++ b/src/components/VideoDisplay/VideoCard/VideoCard.jsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from "react";
 import { useAuth, useLikes, useWatchLater } from "../../../context";
-import { addToWatchLater, likeVideo, unlikeVideo } from "../../../utils";
+import {
+  addToWatchLater,
+  likeVideo,
+  removeFromWatchLater,
+  unlikeVideo,
+} from "../../../utils";
 import { useNavigate } from "react-router-dom";
 import "./VideoCard.css";
 
@@ -54,6 +59,10 @@ export const VideoCard = ({
     }
   };
 
+  const removeFromWatchLaterHandler = (_id) => {
+    removeFromWatchLater(_id, token, watchLaterDispatch, setWatchLater);
+  };
+
   useEffect(() => {
     isLiked(_id);
   });
@@ -105,6 +114,7 @@ export const VideoCard = ({
             <button
               className="button btn-float btn-primary watchlater-button"
               title="Remove from Watch Later"
+              onClick={() => removeFromWatchLaterHandler(_id)}
             >
               <i className="fas fa-clock wl-icon"></i>
             </button>

--- a/src/components/VideoDisplay/VideoCard/VideoCard.jsx
+++ b/src/components/VideoDisplay/VideoCard/VideoCard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
-import { useAuth, useLikes } from "../../../context";
-import { likeVideo, unlikeVideo } from "../../../utils";
+import { useAuth, useLikes, useWatchLater } from "../../../context";
+import { addToWatchLater, likeVideo, unlikeVideo } from "../../../utils";
 import { useNavigate } from "react-router-dom";
 import "./VideoCard.css";
 
@@ -23,12 +23,16 @@ export const VideoCard = ({
     likesState: { likes },
     likesDispatch,
   } = useLikes();
+  const {
+    watchLaterState: { watchlater },
+    watchLaterDispatch,
+  } = useWatchLater();
   const [liked, setLiked] = useState(false);
+  const [watchLater, setWatchLater] = useState(false);
 
   const likeHandler = (_id) => {
     if (token) {
       const video = videos.find((video) => video._id === _id);
-      console.log(videos);
       likeVideo(token, video, likesDispatch, setLiked);
     } else {
       navigate("/login");
@@ -41,6 +45,13 @@ export const VideoCard = ({
 
   const isLiked = (_id) => {
     likes.find((video) => video._id === _id) ? setLiked(true) : setLiked(false);
+  };
+
+  const addToWatchLaterHandler = (_id) => {
+    if (token) {
+      const video = videos.find((video) => video._id === _id);
+      addToWatchLater(token, video, watchLaterDispatch, setWatchLater);
+    }
   };
 
   useEffect(() => {
@@ -89,12 +100,24 @@ export const VideoCard = ({
               <i className="far fa-thumbs-up like-icon"></i>
             </button>
           )}
-          <button
-            className="button btn-float btn-primary watchlater-button"
-            title="Add to Watch Later"
-          >
-            <i className="far fa-clock wl-icon"></i>
-          </button>
+
+          {watchLater ? (
+            <button
+              className="button btn-float btn-primary watchlater-button"
+              title="Remove from Watch Later"
+            >
+              <i className="fas fa-clock wl-icon"></i>
+            </button>
+          ) : (
+            <button
+              className="button btn-float btn-primary watchlater-button"
+              title="Add to Watch Later"
+              onClick={() => addToWatchLaterHandler(_id)}
+            >
+              <i className="far fa-clock wl-icon"></i>
+            </button>
+          )}
+
           <button
             className="button btn-float btn-primary playlist-button"
             title="Add to Playlist"

--- a/src/components/VideoDisplay/VideoCard/VideoCard.jsx
+++ b/src/components/VideoDisplay/VideoCard/VideoCard.jsx
@@ -56,6 +56,8 @@ export const VideoCard = ({
     if (token) {
       const video = videos.find((video) => video._id === _id);
       addToWatchLater(token, video, watchLaterDispatch, setWatchLater);
+    } else {
+      navigate("/login");
     }
   };
 
@@ -71,7 +73,7 @@ export const VideoCard = ({
 
   useEffect(() => {
     isLiked(_id);
-    inWatchLater(_id)
+    inWatchLater(_id);
   });
 
   return (

--- a/src/components/VideoDisplay/VideoCard/VideoCard.jsx
+++ b/src/components/VideoDisplay/VideoCard/VideoCard.jsx
@@ -63,8 +63,15 @@ export const VideoCard = ({
     removeFromWatchLater(_id, token, watchLaterDispatch, setWatchLater);
   };
 
+  const inWatchLater = (_id) => {
+    watchlater.find((video) => video._id === _id)
+      ? setWatchLater(true)
+      : setWatchLater(false);
+  };
+
   useEffect(() => {
     isLiked(_id);
+    inWatchLater(_id)
   });
 
   return (

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,3 +1,4 @@
 export { VideoProvider, useVideos } from "./videos-context";
 export { AuthProvider, useAuth } from "./auth-context";
 export { LikesProvider, useLikes } from "./likes-context";
+export { WatchLaterProvider, useWatchLater } from "./watchlater-context";

--- a/src/context/watchlater-context.jsx
+++ b/src/context/watchlater-context.jsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+const WatchLaterContext = createContext(null);
+
+const WatchLaterProvider = ({ children }) => {
+  return <WatchLaterContext.Provider>{children}</WatchLaterContext.Provider>;
+};
+
+const useWatchLater = () => useContext(WatchLaterContext);
+
+export { WatchLaterProvider, useWatchLater };

--- a/src/context/watchlater-context.jsx
+++ b/src/context/watchlater-context.jsx
@@ -1,9 +1,18 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useReducer } from "react";
+import { watchLaterReducer } from "../reducers";
 
 const WatchLaterContext = createContext(null);
 
 const WatchLaterProvider = ({ children }) => {
-  return <WatchLaterContext.Provider>{children}</WatchLaterContext.Provider>;
+  const [watchLaterState, watchLaterDispatch] = useReducer(watchLaterReducer, {
+    watchlater: [],
+  });
+
+  return (
+    <WatchLaterContext.Provider value={{ watchLaterState, watchLaterDispatch }}>
+      {children}
+    </WatchLaterContext.Provider>
+  );
 };
 
 const useWatchLater = () => useContext(WatchLaterContext);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,12 @@ import "./index.css";
 import App from "./App";
 import { makeServer } from "./server";
 import { BrowserRouter as Router } from "react-router-dom";
-import { AuthProvider, LikesProvider, VideoProvider } from "./context/";
+import {
+  AuthProvider,
+  LikesProvider,
+  VideoProvider,
+  WatchLaterProvider,
+} from "./context/";
 
 // Call make Server
 makeServer();
@@ -12,13 +17,15 @@ makeServer();
 ReactDOM.render(
   <React.StrictMode>
     <AuthProvider>
-      <LikesProvider>
-        <VideoProvider>
-          <Router>
-            <App />
-          </Router>
-        </VideoProvider>
-      </LikesProvider>
+      <WatchLaterProvider>
+        <LikesProvider>
+          <VideoProvider>
+            <Router>
+              <App />
+            </Router>
+          </VideoProvider>
+        </LikesProvider>
+      </WatchLaterProvider>
     </AuthProvider>
   </React.StrictMode>,
   document.getElementById("root")

--- a/src/pages/Authentication/Login/Login.jsx
+++ b/src/pages/Authentication/Login/Login.jsx
@@ -1,20 +1,27 @@
 import "./../Auth.css";
 import { Link, useNavigate } from "react-router-dom";
 import { useState } from "react";
-import { useAuth, useLikes } from "../../../context";
+import { useAuth, useLikes, useWatchLater } from "../../../context";
 import { dispatchLogin } from "../../../utils/";
 
 export const Login = () => {
   const [user, setUser] = useState({ email: "", password: "" });
   const { authDispatch } = useAuth();
   const { likesDispatch } = useLikes();
+  const { watchLaterDispatch } = useWatchLater();
   const navigate = useNavigate();
 
   const loginHandler = (e) => {
     e.preventDefault();
 
     if (user.email !== "" && user.password !== "") {
-      dispatchLogin(user, authDispatch, navigate, likesDispatch);
+      dispatchLogin(
+        user,
+        authDispatch,
+        navigate,
+        likesDispatch,
+        watchLaterDispatch
+      );
     } else {
       alert("Please fill up both the fields");
     }

--- a/src/pages/Liked/Liked.jsx
+++ b/src/pages/Liked/Liked.jsx
@@ -40,7 +40,7 @@ export const Liked = () => {
                   videoTime={likedVideo.videoTime}
                   videoTitle={likedVideo.title}
                   channelName={likedVideo.channelName}
-                  removeFromLikes={removeFromLikes}
+                  removeVideo={removeFromLikes}
                   liked={liked}
                 />
               </li>

--- a/src/pages/User/User.jsx
+++ b/src/pages/User/User.jsx
@@ -1,15 +1,17 @@
 import { Link } from "react-router-dom";
-import { useAuth, useLikes } from "../../context";
+import { useAuth, useLikes, useWatchLater } from "../../context";
 import "./User.css";
 
 export const User = () => {
   const { authDispatch } = useAuth();
   const { likesDispatch } = useLikes();
+  const { watchLaterDispatch } = useWatchLater();
   const logoutHandler = () => {
     localStorage.removeItem("user");
     localStorage.removeItem("token");
     authDispatch({ type: "LOGOUT" });
     likesDispatch({ type: "EMPTY_LIKE_PAGE" });
+    watchLaterDispatch({ type: "EMPTY_WATCH_LATER" });
   };
   return (
     <div>

--- a/src/pages/WatchLater/WatchLater.css
+++ b/src/pages/WatchLater/WatchLater.css
@@ -1,6 +1,7 @@
 .watch-later-wrapper {
   display: flex;
   align-items: flex-start;
+  flex-direction: row;
   flex-grow: 1;
   height: 100%;
   width: 100%;
@@ -11,7 +12,16 @@
   justify-content: flex-start;
   align-items: flex-start;
   flex-direction: row;
-  gap: 2rem;
-  flex-wrap: wrap;
+  width: 100%;
   margin: 2rem;
+}
+
+.list {
+  align-items: stretch;
+  width: 65%;
+}
+
+.stacked {
+  border: none;
+  margin: 1rem;
 }

--- a/src/pages/WatchLater/WatchLater.jsx
+++ b/src/pages/WatchLater/WatchLater.jsx
@@ -1,11 +1,24 @@
 import "./WatchLater.css";
-import { SideNav } from "../../components";
+import { HorizontalVideoCard, PageSidePiece, SideNav } from "../../components";
 
 export const WatchLater = () => {
   return (
     <div className="watch-later-wrapper">
       <SideNav />
-      <div className="videos-container">This is Watch Later Page</div>
+      <div className="videos-container">
+        <PageSidePiece pageTitle="Watch Later" numVideos="0" />
+        <ul className="list list-stacked videos-list">
+          <li className="list-item stacked">
+            <HorizontalVideoCard
+              videoId="ID"
+              videoThumbnail="https://picsum.photos/300"
+              videoTime="1:00"
+              videoTitle="Video Title"
+              channelName="Channel Name"
+            />
+          </li>
+        </ul>
+      </div>
     </div>
   );
 };

--- a/src/pages/WatchLater/WatchLater.jsx
+++ b/src/pages/WatchLater/WatchLater.jsx
@@ -1,8 +1,8 @@
 import "./WatchLater.css";
 import { HorizontalVideoCard, PageSidePiece, SideNav } from "../../components";
 import { useAuth, useWatchLater } from "../../context";
-import { removeFromWatchLater } from "../../utils";
-import { useState } from "react";
+import { fetchWatchLater, removeFromWatchLater } from "../../utils";
+import { useState, useEffect } from "react";
 
 export const WatchLater = () => {
   const {
@@ -18,6 +18,12 @@ export const WatchLater = () => {
   const removeVidFromWatchLater = (_id) => {
     removeFromWatchLater(_id, token, watchLaterDispatch, setWatchLater);
   };
+
+  useEffect(() => {
+    if (token) {
+      fetchWatchLater(watchLaterDispatch, token);
+    }
+  });
   return (
     <div className="watch-later-wrapper">
       <SideNav />

--- a/src/pages/WatchLater/WatchLater.jsx
+++ b/src/pages/WatchLater/WatchLater.jsx
@@ -1,22 +1,48 @@
 import "./WatchLater.css";
 import { HorizontalVideoCard, PageSidePiece, SideNav } from "../../components";
+import { useAuth, useWatchLater } from "../../context";
+import { removeFromWatchLater } from "../../utils";
+import { useState } from "react";
 
 export const WatchLater = () => {
+  const {
+    authState: { token },
+  } = useAuth();
+  const {
+    watchLaterState: { watchlater },
+    watchLaterDispatch,
+  } = useWatchLater();
+
+  const [watchLater, setWatchLater] = useState(true);
+
+  const removeVidFromWatchLater = (_id) => {
+    removeFromWatchLater(_id, token, watchLaterDispatch, setWatchLater);
+  };
   return (
     <div className="watch-later-wrapper">
       <SideNav />
       <div className="videos-container">
-        <PageSidePiece pageTitle="Watch Later" numVideos="0" />
+        <PageSidePiece pageTitle="Watch Later" numVideos={watchlater.length} />
         <ul className="list list-stacked videos-list">
-          <li className="list-item stacked">
-            <HorizontalVideoCard
-              videoId="ID"
-              videoThumbnail="https://picsum.photos/300"
-              videoTime="1:00"
-              videoTitle="Video Title"
-              channelName="Channel Name"
-            />
-          </li>
+          {watchlater.length > 0 ? (
+            watchlater.map((watchLaterVideo) => (
+              <li className="list-item stacked" key={watchLaterVideo._id}>
+                <HorizontalVideoCard
+                  videoId={watchLaterVideo._id}
+                  videoThumbnail={watchLaterVideo.videoThumbnail}
+                  videoTime={watchLaterVideo.videoTime}
+                  videoTitle={watchLaterVideo.title}
+                  channelName={watchLaterVideo.channelName}
+                  removeVideo={removeVidFromWatchLater}
+                  watchlater={watchLater}
+                />
+              </li>
+            ))
+          ) : (
+            <div className="no-video-div">
+              You have not added any videos to Watch Later yet
+            </div>
+          )}
         </ul>
       </div>
     </div>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,2 +1,3 @@
 export { authReducer } from "./auth-reducer";
-export {likesReducer} from "./likes-reducer";
+export { likesReducer } from "./likes-reducer";
+export { watchLaterReducer } from "./watch-later-reducer";

--- a/src/reducers/watch-later-reducer.jsx
+++ b/src/reducers/watch-later-reducer.jsx
@@ -1,0 +1,18 @@
+export const watchLaterReducer = (state, action) => {
+  switch (action.type) {
+    case "FETCH_INITIAL_WATCH_LATER":
+      return { ...state, watchlater: action.payload };
+
+    case "ADD_TO_WATCH_LATER":
+      return { ...state, watchlater: action.payload };
+
+    case "REMOVE_FROM_WATCH_LATER":
+      return { ...state, watchlater: action.payload };
+
+    case "EMPTY_WATCH_LATER":
+      return { ...state, watchlater: [] };
+
+    default:
+      return state;
+  }
+};

--- a/src/services/WatchLater/addWatchLaterService.js
+++ b/src/services/WatchLater/addWatchLaterService.js
@@ -1,0 +1,3 @@
+import axios from "axios";
+
+export const addWatchLaterService = (token, video) => axios.post('/api/user/watchlater', {video}, {headers:{ authorization: token }})

--- a/src/services/WatchLater/fetchWatchLaterService.js
+++ b/src/services/WatchLater/fetchWatchLaterService.js
@@ -1,0 +1,4 @@
+import axios from "axios";
+
+export const fetchWatchLaterService = (token) =>
+  axios.get("/api/user/watchlater", { headers: { authorization: token } });

--- a/src/services/WatchLater/removeWatchLaterService.js
+++ b/src/services/WatchLater/removeWatchLaterService.js
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const removeWatchLaterService = (_id, token) =>
+  axios.delete(`/api/user/watchlater/${_id}`, {
+    headers: { authorization: token },
+  });

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -4,3 +4,4 @@ export { signUp } from "./Authentication/signup-service";
 export { likesService } from "./Likes/likesService";
 export { removeLikesService } from "./Likes/removeLikesService";
 export { fetchLikesService } from "./Likes/fetchLikesService";
+export { addWatchLaterService } from "./WatchLater/addWatchLaterService";

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -6,3 +6,4 @@ export { removeLikesService } from "./Likes/removeLikesService";
 export { fetchLikesService } from "./Likes/fetchLikesService";
 export { addWatchLaterService } from "./WatchLater/addWatchLaterService";
 export { removeWatchLaterService } from "./WatchLater/removeWatchLaterService";
+export { fetchWatchLaterService } from "./WatchLater/fetchWatchLaterService";

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -5,3 +5,4 @@ export { likesService } from "./Likes/likesService";
 export { removeLikesService } from "./Likes/removeLikesService";
 export { fetchLikesService } from "./Likes/fetchLikesService";
 export { addWatchLaterService } from "./WatchLater/addWatchLaterService";
+export { removeWatchLaterService } from "./WatchLater/removeWatchLaterService";

--- a/src/utils/Authentication/dispatchLogin.js
+++ b/src/utils/Authentication/dispatchLogin.js
@@ -1,11 +1,13 @@
 import { logIn } from "../../services/";
 import { fetchLikedVideos } from "../Likes/fetch-liked-videos";
+import { fetchWatchLater } from "../WatchLater/fetch-watch-later";
 
 export const dispatchLogin = async (
   user,
   authDispatch,
   navigate,
-  likesDispatch
+  likesDispatch,
+  watchLaterDispatch
 ) => {
   try {
     const res = await logIn(user);
@@ -20,6 +22,7 @@ export const dispatchLogin = async (
         },
       });
       fetchLikedVideos(likesDispatch, res.data.encodedToken);
+      fetchWatchLater(watchLaterDispatch, res.data.encodedToken);
       alert("Successfully Logged In");
       navigate("/");
     }

--- a/src/utils/WatchLater/add-watch-later.js
+++ b/src/utils/WatchLater/add-watch-later.js
@@ -1,0 +1,21 @@
+import { addWatchLaterService } from "../../services";
+
+export const addToWatchLater = async (
+  token,
+  video,
+  watchLaterDispatch,
+  setWatchLater
+) => {
+  try {
+    const res = await addWatchLaterService(token, video);
+    if (res.status === 201) {
+      watchLaterDispatch({
+        type: "ADD_TO_WATCH_LATER",
+        payload: res.data.watchlater,
+      });
+      setWatchLater(true);
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/utils/WatchLater/fetch-watch-later.js
+++ b/src/utils/WatchLater/fetch-watch-later.js
@@ -1,0 +1,15 @@
+import { fetchWatchLaterService } from "../../services";
+
+export const fetchWatchLater = async (watchLaterDispatch, token) => {
+  try {
+    const res = await fetchWatchLaterService(token);
+    if (res.status === 200) {
+      watchLaterDispatch({
+        type: "FETCH_INITIAL_WATCH_LATER",
+        payload: res.data.watchlater,
+      });
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/utils/WatchLater/remove-watch-later.js
+++ b/src/utils/WatchLater/remove-watch-later.js
@@ -1,0 +1,22 @@
+import { removeWatchLaterService } from "../../services";
+
+export const removeFromWatchLater = async (
+  _id,
+  token,
+  watchLaterDispatch,
+  setWatchLater
+) => {
+  try {
+    const res = await removeWatchLaterService(_id, token);
+    if (res.status === 200) {
+      watchLaterDispatch({
+        type: "REMOVE_FROM_WATCH_LATER",
+        payload: res.data.watchlater,
+      });
+    }
+
+    setWatchLater(false);
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,3 +6,4 @@ export { unlikeVideo } from "./Likes/unlike-video";
 export { fetchLikedVideos } from "./Likes/fetch-liked-videos";
 export { addToWatchLater } from "./WatchLater/add-watch-later";
 export { removeFromWatchLater } from "./WatchLater/remove-watch-later";
+export { fetchWatchLater } from "./WatchLater/fetch-watch-later";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,3 +5,4 @@ export { likeVideo } from "./Likes/like-video";
 export { unlikeVideo } from "./Likes/unlike-video";
 export { fetchLikedVideos } from "./Likes/fetch-liked-videos";
 export { addToWatchLater } from "./WatchLater/add-watch-later";
+export { removeFromWatchLater } from "./WatchLater/remove-watch-later";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,3 +4,4 @@ export { dispatchSignUp } from "./Authentication/dispatchSignUp";
 export { likeVideo } from "./Likes/like-video";
 export { unlikeVideo } from "./Likes/unlike-video";
 export { fetchLikedVideos } from "./Likes/fetch-liked-videos";
+export { addToWatchLater } from "./WatchLater/add-watch-later";


### PR DESCRIPTION
Changes to look for in this PR:

- Watch later page styling changed to add sidepiece and horizontal card component
- Navigate to login page if user clicks on Add to Watch later button without logging in on the Explore page
- Navigate to login page if user tries to view watch later page from sidebar without logging in
- Add video to watch later only if logged in
- Remove from watch later only if logged in
- Fetch watch later videos and display on explore page if already in watch later through solid icon
- Empty watch later if user logs out
- View watch later page only if logged in

**Deploy Preview given below**